### PR TITLE
Exit on GRPC CSI connection loss

### DIFF
--- a/cmd/csi-attacher/main.go
+++ b/cmd/csi-attacher/main.go
@@ -122,7 +122,7 @@ func main() {
 		csiAttacher = dummyAttacherName
 	} else {
 		// Connect to CSI.
-		csiConn, err := connection.Connect(*csiAddress)
+		csiConn, err := connection.Connect(*csiAddress, connection.OnConnectionLoss(connection.ExitOnConnectionLoss()))
 		if err != nil {
 			klog.Error(err.Error())
 			os.Exit(1)


### PR DESCRIPTION
Exits the application on a CSI GRPC connection loss.

Replicates behavior of external-provisioner:
https://github.com/kubernetes-csi/external-provisioner/blob/master//pkg/controller/controller.go#L198